### PR TITLE
PUT createCoin endpoint in the Coin router

### DIFF
--- a/src/helpers/errors.js
+++ b/src/helpers/errors.js
@@ -88,6 +88,11 @@ const ERRORS = [
     description: 'Coin Code not found',
   },
   {
+    code: 'coin_already_exists',
+    status: 409,
+    description: "Coin already exists"
+  },
+  {
     code: 'entity_too_large',
     status: 413,
     description: 'The files you are trying to upload are too big.',

--- a/src/helpers/errors.js
+++ b/src/helpers/errors.js
@@ -90,7 +90,7 @@ const ERRORS = [
   {
     code: 'coin_already_exists',
     status: 409,
-    description: "Coin already exists"
+    description: 'Coin already exists',
   },
   {
     code: 'entity_too_large',

--- a/src/models/pg/coin.js
+++ b/src/models/pg/coin.js
@@ -17,6 +17,7 @@ module.exports = function (sequelize, DataTypes) {
       code: {
         type: DataTypes.STRING,
         allowNull: false,
+        unique: true
       },
     },
     {
@@ -35,6 +36,13 @@ module.exports = function (sequelize, DataTypes) {
   Coin.findByCoinCode = function (code, tOpts = {}) {
     return Coin.findOne(Object.assign({ where: { code } }, tOpts));
   };
+
+  Coin.createCoin = function (name, code, tOpts = {}) {
+    return Coin.create({
+      name: name,
+      code: code,
+    }, tOpts)
+  }
 
   return Coin;
 };

--- a/src/models/pg/coin.js
+++ b/src/models/pg/coin.js
@@ -17,7 +17,7 @@ module.exports = function (sequelize, DataTypes) {
       code: {
         type: DataTypes.STRING,
         allowNull: false,
-        unique: true
+        unique: true,
       },
     },
     {
@@ -38,11 +38,14 @@ module.exports = function (sequelize, DataTypes) {
   };
 
   Coin.createCoin = function (name, code, tOpts = {}) {
-    return Coin.create({
-      name: name,
-      code: code,
-    }, tOpts)
-  }
+    return Coin.create(
+      {
+        name: name,
+        code: code,
+      },
+      tOpts
+    );
+  };
 
   return Coin;
 };

--- a/src/services/api/controllers/coin.js
+++ b/src/services/api/controllers/coin.js
@@ -9,6 +9,14 @@ const CoinController = {
 
     return coin.filterKeys();
   },
+
+  async createCoin(name, coinCode) {
+    let coin = await Models.Coin.findByCoinCode(coinCode);
+    errors.assertExposable(!coin, 'coin_already_exists')
+
+    coin = await Models.Coin.createCoin(name, coinCode)
+    return coin.filterKeys()
+  }
 };
 
 module.exports = CoinController;

--- a/src/services/api/controllers/coin.js
+++ b/src/services/api/controllers/coin.js
@@ -12,11 +12,11 @@ const CoinController = {
 
   async createCoin(name, coinCode) {
     let coin = await Models.Coin.findByCoinCode(coinCode);
-    errors.assertExposable(!coin, 'coin_already_exists')
+    errors.assertExposable(!coin, 'coin_already_exists');
 
-    coin = await Models.Coin.createCoin(name, coinCode)
-    return coin.filterKeys()
-  }
+    coin = await Models.Coin.createCoin(name, coinCode);
+    return coin.filterKeys();
+  },
 };
 
 module.exports = CoinController;

--- a/src/services/api/routers/coin.js
+++ b/src/services/api/routers/coin.js
@@ -8,6 +8,11 @@ const CoinRouter = {
     coinCode: Joi.string().min(3).uppercase().max(5),
   }),
 
+  schemaPutCoinCode: Joi.object({
+    coinCode: Joi.string().min(3).uppercase().max(5),
+    name: Joi.string()
+  }),
+
   async getCoinByCode(ctx) {
     const params = {
       coinCode: ctx.params.coinCode,
@@ -18,13 +23,22 @@ const CoinRouter = {
     ctx.body = await CoinController.getCoinByCode(formattedParams.coinCode);
   },
 
+  async putCoin(ctx) {
+    const params = {
+      coinCode: ctx.request.body.coinCode,
+      name: ctx.request.body.name
+    }
+    const formattedParams = await validateParams(CoinRouter.putCoinByCode, params)
+    ctx.body = await CoinController.createCoin(formattedParams);
+  },
+
   router() {
     const router = Router();
 
     /**
      * @api {get} / Get coinCode
      * @apiName coinCode
-     * @apiGroup Status
+     * @apiGroup Coin
      * @apiDescription Get coinCode
      *
      * @apiSampleRequest /
@@ -32,6 +46,19 @@ const CoinRouter = {
      */
     router.get('/:coinCode', CoinRouter.getCoinByCode);
 
+    /**
+     * @api {put} /createCoin Create a coin
+     * @apiName createCoin
+     * @apiGroup Coin
+     * @apiDescription create coin
+     * 
+     * 
+     * @apiParam {String} coinCode The code of the coin
+     * @apiParam {String} name The name of the coin
+     * @apiSampleRequest /createCoin
+     * 
+     */
+    router.put('/createCoin', CoinRouter.putCoin);
     return router;
   },
 };

--- a/src/services/api/routers/coin.js
+++ b/src/services/api/routers/coin.js
@@ -10,7 +10,7 @@ const CoinRouter = {
 
   schemaPutCoinCode: Joi.object({
     coinCode: Joi.string().min(3).uppercase().max(5),
-    name: Joi.string()
+    name: Joi.string(),
   }),
 
   async getCoinByCode(ctx) {
@@ -26,9 +26,9 @@ const CoinRouter = {
   async putCoin(ctx) {
     const params = {
       coinCode: ctx.request.body.coinCode,
-      name: ctx.request.body.name
-    }
-    const formattedParams = await validateParams(CoinRouter.putCoinByCode, params)
+      name: ctx.request.body.name,
+    };
+    const formattedParams = await validateParams(CoinRouter.putCoinByCode, params);
     ctx.body = await CoinController.createCoin(formattedParams);
   },
 
@@ -51,12 +51,12 @@ const CoinRouter = {
      * @apiName createCoin
      * @apiGroup Coin
      * @apiDescription create coin
-     * 
-     * 
+     *
+     *
      * @apiParam {String} coinCode The code of the coin
      * @apiParam {String} name The name of the coin
      * @apiSampleRequest /createCoin
-     * 
+     *
      */
     router.put('/createCoin', CoinRouter.putCoin);
     return router;

--- a/test/unit/models/pg/coin.spec.js
+++ b/test/unit/models/pg/coin.spec.js
@@ -19,7 +19,7 @@ describe('Model:coin', () => {
   });
 
   it('Should create', async () => {
-    const coin = await Models.Coin.createCoin('Bitcoin Cash','BCH')
+    const coin = await Models.Coin.createCoin('Bitcoin Cash', 'BCH');
 
     expect(coin.name).to.eq('Bitcoin Cash');
     expect(coin.code).to.eq('BCH');

--- a/test/unit/models/pg/coin.spec.js
+++ b/test/unit/models/pg/coin.spec.js
@@ -19,10 +19,7 @@ describe('Model:coin', () => {
   });
 
   it('Should create', async () => {
-    const coin = await Models.Coin.create({
-      name: 'Bitcoin Cash',
-      code: 'BCH',
-    });
+    const coin = await Models.Coin.createCoin('Bitcoin Cash','BCH')
 
     expect(coin.name).to.eq('Bitcoin Cash');
     expect(coin.code).to.eq('BCH');

--- a/test/unit/services/api/controllers/coin.spec.js
+++ b/test/unit/services/api/controllers/coin.spec.js
@@ -31,4 +31,20 @@ describe('Controller: Coin', () => {
       expect(CoinController.getCoinByCode(coinCode)).to.be.rejectedWith(Error, 'unknown_coin_code');
     });
   });
+
+  describe('createCoin', () => {
+    const coinCode = 'ETC'
+    const coinName = 'Ether Classic'
+
+    it('should create a new coin', async () => {
+      const coin = await CoinController.createCoin(coinName, coinCode)
+      expect(coin.code).to.eq(coinCode)
+      expect(coin.name).to.eq(coinName)
+    })
+
+    it('should refuse creating the same coin if it exists', async () => {
+      await CoinController.createCoin(coinName, coinCode)
+      expect(CoinController.createCoin(coinName, coinCode)).to.be.rejectedWith(Error, 'coin_already_exists')
+    })
+  })
 });

--- a/test/unit/services/api/controllers/coin.spec.js
+++ b/test/unit/services/api/controllers/coin.spec.js
@@ -33,18 +33,18 @@ describe('Controller: Coin', () => {
   });
 
   describe('createCoin', () => {
-    const coinCode = 'ETC'
-    const coinName = 'Ether Classic'
+    const coinCode = 'ETC';
+    const coinName = 'Ether Classic';
 
     it('should create a new coin', async () => {
-      const coin = await CoinController.createCoin(coinName, coinCode)
-      expect(coin.code).to.eq(coinCode)
-      expect(coin.name).to.eq(coinName)
-    })
+      const coin = await CoinController.createCoin(coinName, coinCode);
+      expect(coin.code).to.eq(coinCode);
+      expect(coin.name).to.eq(coinName);
+    });
 
     it('should refuse creating the same coin if it exists', async () => {
-      await CoinController.createCoin(coinName, coinCode)
-      expect(CoinController.createCoin(coinName, coinCode)).to.be.rejectedWith(Error, 'coin_already_exists')
-    })
-  })
+      await CoinController.createCoin(coinName, coinCode);
+      expect(CoinController.createCoin(coinName, coinCode)).to.be.rejectedWith(Error, 'coin_already_exists');
+    });
+  });
 });


### PR DESCRIPTION
- Created `coin_already_exists` error
- Set the coin code column to be required unique by postgresql
- Added `createCoin` method to the `Coin` Model
- Added `createCoin` method to the `Coin` Controller
- Added Joi schema and boilerplate for `PUT /createCoin` endpoint in the `Coin` router
- Added unitests for everything 

note: code is only missing coverage goal by %0.25 so I think it's best to try addressing coverage issues when the code is done.
