### PR TITLE
Return coin price on `GET /coin/:coinCode`  and cache it for 1 hour

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,8 @@
     "uuid": "^8.3.2",
     "winston": "^3.3.3",
     "winston-transport": "^4.4.0",
-    "ws": "^8.2.3"
+    "ws": "^8.2.3",
+    "nock": "^13.2.4"
   },
   "devDependencies": {
     "sequelize-cli": "^6.3.0"

--- a/src/helpers/coingecko-api.js
+++ b/src/helpers/coingecko-api.js
@@ -8,7 +8,7 @@ const logger = require('../modules/logger');
  */
 module.exports.getCoinGeckoIDfromCoinCode = async function (coinCode) {
   const coinGeckoList = await superagent.get('https://api.coingecko.com/api/v3/coins/list');
-  coinGeckoListing = coinGeckoList.body.find((coin) => {
+  const coinGeckoListing = coinGeckoList.body.find((coin) => {
     if (coin.symbol === coinCode.toLowerCase()) return true;
   });
 

--- a/src/helpers/coingecko-api.js
+++ b/src/helpers/coingecko-api.js
@@ -9,13 +9,13 @@ const logger = require('../modules/logger');
 module.exports.getCoinGeckoIDfromCoinCode = async function (coinCode) {
   const coinGeckoList = await superagent.get('https://api.coingecko.com/api/v3/coins/list');
   coinGeckoListing = coinGeckoList.body.find((coin) => {
-    if (coin.symbol === coinCode.toLowerCase()) return true
-  })
+    if (coin.symbol === coinCode.toLowerCase()) return true;
+  });
 
   if (coinGeckoListing) {
-    return coinGeckoListing.id
+    return coinGeckoListing.id;
   }
-  return false
+  return false;
 };
 
 /**
@@ -26,10 +26,8 @@ module.exports.getCoinGeckoIDfromCoinCode = async function (coinCode) {
 module.exports.fetchCoinPrice = async function (coinGeckoID) {
   try {
     const coinPriceInUSD = await superagent.get('https://api.coingecko.com/api/v3/simple/price', {
-
       ids: coinGeckoID,
       vs_currencies: 'USD',
-
     });
     return coinPriceInUSD.body[coinGeckoID]['usd'];
   } catch (e) {

--- a/src/helpers/coingecko-api.js
+++ b/src/helpers/coingecko-api.js
@@ -1,0 +1,39 @@
+const superagent = require('superagent');
+const logger = require('../modules/logger');
+
+/**
+ * does a bruteforce search all coins that geckoCoin has until it finds a coin with the corrosponsind symbol
+ * @param {*} coinCode
+ * @returns the coinGeckoID for the coinCode("symbol" or "ticker") || an empty string if coinGecko doesn't know the coinCode
+ */
+module.exports.getCoinGeckoIDfromCoinCode = async function (coinCode) {
+  const coinGeckoList = await superagent.get('https://api.coingecko.com/api/v3/coins/list');
+  coinGeckoListing = coinGeckoList.body.find((coin) => {
+    if (coin.symbol === coinCode.toLowerCase()) return true
+  })
+
+  if (coinGeckoListing) {
+    return coinGeckoListing.id
+  }
+  return false
+};
+
+/**
+ * gets current coin price from coinGecko
+ * @param {*} coinGeckoID
+ * @returns coin price in USD
+ */
+module.exports.fetchCoinPrice = async function (coinGeckoID) {
+  try {
+    const coinPriceInUSD = await superagent.get('https://api.coingecko.com/api/v3/simple/price', {
+
+      ids: coinGeckoID,
+      vs_currencies: 'USD',
+
+    });
+    return coinPriceInUSD.body[coinGeckoID]['usd'];
+  } catch (e) {
+    logger.warn(e);
+    return;
+  }
+};

--- a/src/helpers/errors.js
+++ b/src/helpers/errors.js
@@ -68,6 +68,11 @@ const ERRORS = [
     description: 'Bad parameters',
   },
   {
+    code: 'invalid_coin_code',
+    status: 400,
+    description: 'invalid coin code',
+  },
+  {
     code: 'access_denied',
     status: 401,
     description: 'You are trying to access to a forbidden resource',

--- a/src/models/pg/coin.js
+++ b/src/models/pg/coin.js
@@ -19,6 +19,12 @@ module.exports = function (sequelize, DataTypes) {
         allowNull: false,
         unique: true,
       },
+      price: {
+        type: DataTypes.DECIMAL
+      },
+      priceLastUpdated: {
+        type: DataTypes.DATE
+      }
     },
     {
       freezeTableName: true,
@@ -28,7 +34,7 @@ module.exports = function (sequelize, DataTypes) {
 
   Coin.prototype.filterKeys = function () {
     const obj = this.toObject();
-    const filtered = pick(obj, 'id', 'name', 'code');
+    const filtered = pick(obj, 'id', 'name', 'code', 'price');
 
     return filtered;
   };
@@ -36,6 +42,14 @@ module.exports = function (sequelize, DataTypes) {
   Coin.findByCoinCode = function (code, tOpts = {}) {
     return Coin.findOne(Object.assign({ where: { code } }, tOpts));
   };
+
+  Coin.updateCoinPrice = async function (code, price, tOpts = {}) {
+    const coin = await Coin.findByCoinCode(code, tOpts)
+    coin.price = price
+    coin.priceLastUpdated = new Date()
+    coin.save()
+    return coin
+  }
 
   Coin.createCoin = function (name, code, tOpts = {}) {
     return Coin.create(

--- a/src/models/pg/coin.js
+++ b/src/models/pg/coin.js
@@ -41,7 +41,7 @@ module.exports = function (sequelize, DataTypes) {
 
   Coin.prototype.filterKeys = function () {
     const obj = this.toObject();
-    const filtered = pick(obj, 'id', 'name', 'code', 'price','priceLastUpdated');
+    const filtered = pick(obj, 'id', 'name', 'code', 'price', 'priceLastUpdated');
 
     return filtered;
   };

--- a/src/services/api/controllers/coin.js
+++ b/src/services/api/controllers/coin.js
@@ -1,12 +1,18 @@
 const errors = require('../../../helpers/errors');
 const Models = require('../../../models/pg');
+const { fetchCoinPrice, getCoinGeckoIDfromCoinCode } = require('../../../helpers/coingecko-api');
 
 const CoinController = {
   async getCoinByCode(coinCode) {
-    const coin = await Models.Coin.findByCoinCode(coinCode);
+    let coin = await Models.Coin.findByCoinCode(coinCode);
 
     errors.assertExposable(coin, 'unknown_coin_code');
 
+    // if the last update was an hour ago check coingecko for an update
+    if (coin.priceLastUpdated < new Date() - 1000 * 60 * 60 || !coin.priceLastUpdated) {
+      const price = await fetchCoinPrice(coin.coinGeckoID);
+      if (price) coin = await Models.Coin.updateCoinPrice(coinCode, price);
+    }
     return coin.filterKeys();
   },
 
@@ -14,7 +20,10 @@ const CoinController = {
     let coin = await Models.Coin.findByCoinCode(coinCode);
     errors.assertExposable(!coin, 'coin_already_exists');
 
-    coin = await Models.Coin.createCoin(name, coinCode);
+    const coinGeckoID = await getCoinGeckoIDfromCoinCode(coinCode);
+    errors.assertExposable(coinGeckoID, 'invalid_coin_code'); // throw an error if coinGecko doesn't know the coin
+
+    coin = await Models.Coin.createCoin(name, coinCode, coinGeckoID);
     return coin.filterKeys();
   },
 };

--- a/test/mocks/coingecko-nock.js
+++ b/test/mocks/coingecko-nock.js
@@ -1,0 +1,36 @@
+const nock = require('nock')
+
+module.exports.mockCoingecko = () => {
+    return nock('https://api.coingecko.com')
+        .get('/api/v3/coins/list')
+        .reply(200, [{
+            symbol: "btc",
+            name: "Bitcoin",
+            id: "bitcoin"
+        }, {
+            symbol: "bch",
+            name: "Bitcoin Cash",
+            id: "bitcoin-cash"
+        }, {
+            symbol: 'etc',
+            name: 'ethereum classic',
+            id: 'ethereum-classic'
+        }])
+        .get('/api/v3/simple/price')
+        .query({
+            ids: 'bitcoin',
+            vs_currencies: 'USD'
+        })
+        .reply(200, 
+            {
+                'bitcoin': {
+                    'usd': 2000
+                }
+            }
+        )
+
+}
+
+module.exports.unmockCoingecko = () => {
+    return nock.restore()
+}

--- a/test/mocks/coingecko-nock.js
+++ b/test/mocks/coingecko-nock.js
@@ -1,36 +1,37 @@
-const nock = require('nock')
+const nock = require('nock');
 
 module.exports.mockCoingecko = () => {
-    return nock('https://api.coingecko.com')
-        .get('/api/v3/coins/list')
-        .reply(200, [{
-            symbol: "btc",
-            name: "Bitcoin",
-            id: "bitcoin"
-        }, {
-            symbol: "bch",
-            name: "Bitcoin Cash",
-            id: "bitcoin-cash"
-        }, {
-            symbol: 'etc',
-            name: 'ethereum classic',
-            id: 'ethereum-classic'
-        }])
-        .get('/api/v3/simple/price')
-        .query({
-            ids: 'bitcoin',
-            vs_currencies: 'USD'
-        })
-        .reply(200, 
-            {
-                'bitcoin': {
-                    'usd': 2000
-                }
-            }
-        )
-
-}
+  return nock('https://api.coingecko.com')
+    .get('/api/v3/coins/list')
+    .reply(200, [
+      {
+        symbol: 'btc',
+        name: 'Bitcoin',
+        id: 'bitcoin',
+      },
+      {
+        symbol: 'bch',
+        name: 'Bitcoin Cash',
+        id: 'bitcoin-cash',
+      },
+      {
+        symbol: 'etc',
+        name: 'ethereum classic',
+        id: 'ethereum-classic',
+      },
+    ])
+    .get('/api/v3/simple/price')
+    .query({
+      ids: 'bitcoin',
+      vs_currencies: 'USD',
+    })
+    .reply(200, {
+      bitcoin: {
+        usd: 2000,
+      },
+    });
+};
 
 module.exports.unmockCoingecko = () => {
-    return nock.restore()
-}
+  return nock.restore();
+};

--- a/test/mocks/coins.json
+++ b/test/mocks/coins.json
@@ -4,7 +4,8 @@
     "data": {
       "id": "26a05507-0395-447a-bbbb-000000000000",
       "name": "Bitcoin",
-      "code": "BTC"
+      "code": "BTC",
+      "coinGeckoID": "bitcoin"
     }
   },
   {
@@ -12,7 +13,8 @@
     "data": {
       "id": "26a05507-0395-447a-bbbb-000000000001",
       "name": "Ethereum",
-      "code": "ETH"
+      "code": "ETH",
+      "coinGeckoID": "ethereum"
     }
   }
 ]

--- a/test/unit/helpers/coingecko-api.spec.js
+++ b/test/unit/helpers/coingecko-api.spec.js
@@ -1,39 +1,37 @@
-
 const sinon = require('sinon');
 const path = require('path');
 const { getCoinGeckoIDfromCoinCode, fetchCoinPrice } = require(path.join(srcDir, '/helpers/coingecko-api.js'));
-const { mockCoingecko, unmockCoingecko } = require('../../mocks/coingecko-nock')
+const { mockCoingecko, unmockCoingecko } = require('../../mocks/coingecko-nock');
 
 describe('CoinGecko API helper', () => {
   let sandbox = null;
 
   beforeEach(function () {
-    mockCoingecko()
+    mockCoingecko();
     sandbox = sinon.createSandbox();
   });
 
   after(function () {
     sandbox && sandbox.restore();
-    unmockCoingecko()
+    unmockCoingecko();
   });
 
   describe('getCoinGeckoIDfromCoinCode', () => {
     it('should get the id', async () => {
-      const coingeckoID = await getCoinGeckoIDfromCoinCode('BTC')
-      expect(coingeckoID).to.eq('bitcoin')
-
+      const coingeckoID = await getCoinGeckoIDfromCoinCode('BTC');
+      expect(coingeckoID).to.eq('bitcoin');
     });
 
     it('should return false on a bad coinCode', async () => {
-      const coingeckoID = await getCoinGeckoIDfromCoinCode('fake coin')
-      expect(coingeckoID).to.eq(false)
+      const coingeckoID = await getCoinGeckoIDfromCoinCode('fake coin');
+      expect(coingeckoID).to.eq(false);
     });
   });
 
   describe('fetchCoinPrice', () => {
     it('should fetch coin price', async () => {
-      const price = await fetchCoinPrice('bitcoin')
-      expect(price).to.greaterThan(1)
+      const price = await fetchCoinPrice('bitcoin');
+      expect(price).to.greaterThan(1);
     });
   });
 });

--- a/test/unit/helpers/coingecko-api.spec.js
+++ b/test/unit/helpers/coingecko-api.spec.js
@@ -1,0 +1,39 @@
+
+const sinon = require('sinon');
+const path = require('path');
+const { getCoinGeckoIDfromCoinCode, fetchCoinPrice } = require(path.join(srcDir, '/helpers/coingecko-api.js'));
+const { mockCoingecko, unmockCoingecko } = require('../../mocks/coingecko-nock')
+
+describe('CoinGecko API helper', () => {
+  let sandbox = null;
+
+  beforeEach(function () {
+    mockCoingecko()
+    sandbox = sinon.createSandbox();
+  });
+
+  after(function () {
+    sandbox && sandbox.restore();
+    unmockCoingecko()
+  });
+
+  describe('getCoinGeckoIDfromCoinCode', () => {
+    it('should get the id', async () => {
+      const coingeckoID = await getCoinGeckoIDfromCoinCode('BTC')
+      expect(coingeckoID).to.eq('bitcoin')
+
+    });
+
+    it('should return false on a bad coinCode', async () => {
+      const coingeckoID = await getCoinGeckoIDfromCoinCode('fake coin')
+      expect(coingeckoID).to.eq(false)
+    });
+  });
+
+  describe('fetchCoinPrice', () => {
+    it('should fetch coin price', async () => {
+      const price = await fetchCoinPrice('bitcoin')
+      expect(price).to.greaterThan(1)
+    });
+  });
+});

--- a/test/unit/models/pg/coin.spec.js
+++ b/test/unit/models/pg/coin.spec.js
@@ -41,4 +41,14 @@ describe('Model:coin', () => {
     const filterCoin = coin.filterKeys();
     expect(Object.keys(filterCoin).length).to.eq(3);
   });
+
+  it('Should update coin price', async () => {
+    await Models.Coin.createCoin('Bitcoin Cash', 'BCH')
+    const coin = await Models.Coin.updateCoinPrice('BCH', 350)
+    
+    expect(coin.price).to.eq(350)
+    // check if the dates are updated to within the "current date"
+    expect(coin.priceLastUpdated.valueOf()).to.approximately(new Date().valueOf(),100)
+  })
+
 });

--- a/test/unit/models/pg/coin.spec.js
+++ b/test/unit/models/pg/coin.spec.js
@@ -19,10 +19,11 @@ describe('Model:coin', () => {
   });
 
   it('Should create', async () => {
-    const coin = await Models.Coin.createCoin('Bitcoin Cash','BCH')
+    const coin = await Models.Coin.createCoin('Bitcoin Cash', 'BCH', 'bitcoin-cash');
 
     expect(coin.name).to.eq('Bitcoin Cash');
     expect(coin.code).to.eq('BCH');
+    expect(coin.coinGeckoID).to.eq('bitcoin-cash');
   });
 
   it('Should find by coinCode', async () => {
@@ -33,22 +34,18 @@ describe('Model:coin', () => {
   });
 
   it('Should filterKeys', async () => {
-    const coin = await Models.Coin.create({
-      name: 'Amon',
-      code: 'AMN',
-    });
+    const coin = await Models.Coin.createCoin('Bitcoin Cash', 'BCH', 'bitcoin-cash');
 
     const filterCoin = coin.filterKeys();
     expect(Object.keys(filterCoin).length).to.eq(3);
   });
 
   it('Should update coin price', async () => {
-    await Models.Coin.createCoin('Bitcoin Cash', 'BCH')
-    const coin = await Models.Coin.updateCoinPrice('BCH', 350)
-    
-    expect(coin.price).to.eq(350)
-    // check if the dates are updated to within the "current date"
-    expect(coin.priceLastUpdated.valueOf()).to.approximately(new Date().valueOf(),100)
-  })
+    await Models.Coin.createCoin('Bitcoin Cash', 'BCH', 'bitcoin-cash');
+    const coin = await Models.Coin.updateCoinPrice('BCH', 350);
 
+    expect(coin.price).to.eq(350);
+    // check if the dates are updated to within the "current date"
+    expect(coin.priceLastUpdated.valueOf()).to.approximately(new Date().valueOf(), 100);
+  });
 });

--- a/test/unit/services/api/controllers/coin.spec.js
+++ b/test/unit/services/api/controllers/coin.spec.js
@@ -3,7 +3,7 @@ const sinon = require('sinon');
 const sequelizeMockingMocha = require('sequelize-mocking').sequelizeMockingMocha;
 const CoinController = require(path.join(srcDir, '/services/api/controllers/coin'));
 const DB = require(path.join(srcDir, 'modules/db'));
-const { mockCoingecko, unmockCoingecko } = require('../../../../mocks/coingecko-nock')
+const { mockCoingecko, unmockCoingecko } = require('../../../../mocks/coingecko-nock');
 
 describe('Controller: Coin', () => {
   let sandbox = null;
@@ -11,12 +11,12 @@ describe('Controller: Coin', () => {
   sequelizeMockingMocha(DB.sequelize, [path.resolve('test/mocks/coins.json')], { logging: false });
 
   beforeEach(async () => {
-    mockCoingecko()
+    mockCoingecko();
     sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {
-    unmockCoingecko()
+    unmockCoingecko();
     sandbox && sandbox.restore();
   });
 
@@ -33,12 +33,10 @@ describe('Controller: Coin', () => {
       const coinCode = 'BTC';
       await CoinController.getCoinByCode(coinCode); // fetch current price
 
-
       sinon.useFakeTimers(new Date(+new Date() + 60 * 1000 * 30).getTime()); // advance clock by 30m
       let coin2 = await CoinController.getCoinByCode(coinCode);
       // check if priceLastUpdated is approx 30m ago
       expect(coin2.priceLastUpdated.valueOf()).to.approximately(new Date(+new Date() - 60 * 1000 * 30).valueOf(), 1000);
-
 
       clock = sinon.useFakeTimers(new Date(+new Date() + 60 * 1000 * 31).getTime()); // advance clock by 31m
       let coin3 = await CoinController.getCoinByCode(coinCode);

--- a/test/unit/services/api/controllers/coin.spec.js
+++ b/test/unit/services/api/controllers/coin.spec.js
@@ -3,6 +3,7 @@ const sinon = require('sinon');
 const sequelizeMockingMocha = require('sequelize-mocking').sequelizeMockingMocha;
 const CoinController = require(path.join(srcDir, '/services/api/controllers/coin'));
 const DB = require(path.join(srcDir, 'modules/db'));
+const { mockCoingecko, unmockCoingecko } = require('../../../../mocks/coingecko-nock')
 
 describe('Controller: Coin', () => {
   let sandbox = null;
@@ -10,10 +11,12 @@ describe('Controller: Coin', () => {
   sequelizeMockingMocha(DB.sequelize, [path.resolve('test/mocks/coins.json')], { logging: false });
 
   beforeEach(async () => {
+    mockCoingecko()
     sandbox = sinon.createSandbox();
   });
 
   afterEach(() => {
+    unmockCoingecko()
     sandbox && sandbox.restore();
   });
 
@@ -23,9 +26,27 @@ describe('Controller: Coin', () => {
       const coin = await CoinController.getCoinByCode(coinCode);
 
       expect(coin.code).to.eq(coinCode);
-      expect(Object.keys(coin).length).to.eq(3);
+      expect(Object.keys(coin).length).to.eq(5);
     });
 
+    it('should update coin price if an hour passes', async () => {
+      const coinCode = 'BTC';
+      await CoinController.getCoinByCode(coinCode); // fetch current price
+
+
+      sinon.useFakeTimers(new Date(+new Date() + 60 * 1000 * 30).getTime()); // advance clock by 30m
+      let coin2 = await CoinController.getCoinByCode(coinCode);
+      // check if priceLastUpdated is approx 30m ago
+      expect(coin2.priceLastUpdated.valueOf()).to.approximately(new Date(+new Date() - 60 * 1000 * 30).valueOf(), 1000);
+
+
+      clock = sinon.useFakeTimers(new Date(+new Date() + 60 * 1000 * 31).getTime()); // advance clock by 31m
+      let coin3 = await CoinController.getCoinByCode(coinCode);
+      // check if the priceLastUpdated is now
+      expect(coin3.priceLastUpdated.valueOf()).to.approximately(new Date().valueOf(), 1000);
+
+      clock.restore();
+    });
     it('should fail get coin by code', async () => {
       const coinCode = 'AMN';
       expect(CoinController.getCoinByCode(coinCode)).to.be.rejectedWith(Error, 'unknown_coin_code');
@@ -45,6 +66,10 @@ describe('Controller: Coin', () => {
     it('should refuse creating the same coin if it exists', async () => {
       await CoinController.createCoin(coinName, coinCode);
       expect(CoinController.createCoin(coinName, coinCode)).to.be.rejectedWith(Error, 'coin_already_exists');
+    });
+
+    it('should refuse creating a coin with an invalid coinCode', () => {
+      expect(CoinController.createCoin(coinName, 'fakecoin')).to.be.rejectedWith(Error, 'invalid_coin_code');
     });
   });
 });

--- a/test/unit/services/api/controllers/coin.spec.js
+++ b/test/unit/services/api/controllers/coin.spec.js
@@ -38,7 +38,7 @@ describe('Controller: Coin', () => {
       // check if priceLastUpdated is approx 30m ago
       expect(coin2.priceLastUpdated.valueOf()).to.approximately(new Date(+new Date() - 60 * 1000 * 30).valueOf(), 1000);
 
-      clock = sinon.useFakeTimers(new Date(+new Date() + 60 * 1000 * 31).getTime()); // advance clock by 31m
+      const clock = sinon.useFakeTimers(new Date(+new Date() + 60 * 1000 * 31).getTime()); // advance clock by 31m
       let coin3 = await CoinController.getCoinByCode(coinCode);
       // check if the priceLastUpdated is now
       expect(coin3.priceLastUpdated.valueOf()).to.approximately(new Date().valueOf(), 1000);


### PR DESCRIPTION
## Summary
- fetch coin price from coingecko and store it. If the last fetch time was an hour ago: refresh it 

- Create coingecko API wrapper with tests and mockups using [superagent](https://github.com/visionmedia/superagent) and [nock](https://github.com/nock/nock)
- Added mechanism in `CoinController.getCoinByCode()` method to fetch new prices if the last update to the price was more than an hour ago



## Changes to the Coin database table
- Added `updateCoinPrice` Method to the `Coin` pg model
- Added `price` and  `priceLastUpdated`  columns to the pg model

## Changes to Coin Creation flow
- On coin creation store `coingeckoID` to the database to use for further querying of the coingecko API
- Added creation check to see if coingecko recognizes the coin symbol before creating it. Throws a `invalid_coin_code` if coingecko doesn't know the code.